### PR TITLE
Net fixup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scipy==0.17.1
 matplotlib==1.5.3
 pandas==0.19.2
 scikit-learn==0.18
+jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ scipy==0.17.1
 matplotlib==1.5.3
 pandas==0.19.2
 scikit-learn==0.18
-jsonschema
+jsonschema==2.6.0

--- a/src/net.py
+++ b/src/net.py
@@ -23,6 +23,7 @@ from ops import activations, optimizers
 
 import json
 
+
 import cPickle as pickle
 
 from sklearn.utils import shuffle
@@ -140,14 +141,20 @@ class Network(object):
 
         returns a network.
         """
+        import jsonschema
+        import schemas
         mode = config.get('mode')
         if mode == 'dense':
+            jsonschema.validate(config, schemas.dense_network)
+
             network = self.create_dense_network(
                 units=config.get('units'),
                 dropouts=config.get('dropouts'),
                 nonlinearity=nonlinearity
             )
         elif mode == 'conv':
+            jsonschema.validate(config, schemas.conv_network)
+
             network = self.create_conv_network(
                 filters=config.get('filters'),
                 filter_size=config.get('filter_size'),

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -6,7 +6,9 @@ dense_network = {
             "id": "/properties/dropouts",
             "items": {
                 "id": "/properties/dropouts/items",
-                "type": "number"
+                "type": "number",
+                "maximum": 1,
+                "minimum": 0
             },
             "type": "array"
         },
@@ -18,7 +20,8 @@ dense_network = {
             "id": "/properties/units",
             "items": {
                 "id": "/properties/units/items",
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
             },
             "type": "array"
         }
@@ -34,7 +37,8 @@ conv_network = {
                 "id": "/properties/filter_size/items",
                 "items": {
                     "id": "/properties/filter_size/items/items",
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 1
                 },
                 "type": "array"
             },
@@ -44,7 +48,8 @@ conv_network = {
             "id": "/properties/filters",
             "items": {
                 "id": "/properties/filters/items",
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1
             },
             "type": "array"
         },
@@ -57,7 +62,8 @@ conv_network = {
             "properties": {
                 "mode": {
                     "id": "/properties/pool/properties/mode",
-                    "type": "string"
+                    "type": "string",
+                    "enum": ["max", "average_inc_pad", "average_exc_pad"]
                 },
                 "stride": {
                     "id": "/properties/pool/properties/stride",
@@ -65,7 +71,8 @@ conv_network = {
                         "id": "/properties/pool/properties/stride/items",
                         "items": {
                             "id": "/properties/pool/properties/stride/items/items",
-                            "type": "integer"
+                            "type": "integer",
+                            "minimum": 1
                         },
                         "type": "array"
                     },
@@ -80,7 +87,8 @@ conv_network = {
                 "id": "/properties/stride/items",
                 "items": {
                     "id": "/properties/stride/items/items",
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 1
                 },
                 "type": "array"
             },


### PR DESCRIPTION
Housekeeping on net.py

7a3924e makes many small changes to clean up src/net.py. Mostly typo/formatting fixes, though I also changed some documentation that was out-of-date and added some Nones to appease the linter.

1633640 adds validation for the config dicts against the schemas in schemas.py to net.py.  Schemas made a little stricter so we fail quickly on bad inputs (e.g., dropouts not in [0, 1]). Note that this commit adds jsonschema to requirements.txt
